### PR TITLE
Fix warning about unused capture

### DIFF
--- a/core_lib/soundplayer.cpp
+++ b/core_lib/soundplayer.cpp
@@ -92,7 +92,7 @@ void SoundPlayer::setMediaPlayerPosition(qint64 pos)
 void SoundPlayer::makeConnections()
 {   
     auto errorSignal = static_cast< void ( QMediaPlayer::* )( QMediaPlayer::Error ) >( &QMediaPlayer::error );
-    connect( mMediaPlayer, errorSignal, this, [ this ]( QMediaPlayer::Error err )
+    connect( mMediaPlayer, errorSignal, this, []( QMediaPlayer::Error err )
     {
         qDebug() << "MediaPlayer Error: " << err;
     } );


### PR DESCRIPTION
```
../../core_lib/soundplayer.cpp:95:49: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
    connect( mMediaPlayer, errorSignal, this, [ this ]( QMediaPlayer::Error err )
                                                ^
```