### PR TITLE
Refactor selectionmanager and movetool

### DIFF
--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -85,6 +85,7 @@ HEADERS +=  \
     src/util/blitrect.h \
     src/util/colordictionary.h \
     src/util/fileformat.h \
+    src/util/mathutils.h \
     src/util/pencildef.h \
     src/util/pencilerror.h \
     src/util/pencilsettings.h \

--- a/core_lib/src/managers/selectionmanager.cpp
+++ b/core_lib/src/managers/selectionmanager.cpp
@@ -6,6 +6,7 @@
 #include "bitmapimage.h"
 
 #include "layervector.h"
+#include "mathutils.h"
 
 //#ifdef QT_DEBUG
 #include <QDebug>
@@ -264,12 +265,7 @@ int SelectionManager::constrainRotationToAngle(const qreal& rotatedAngle, const 
 qreal SelectionManager::rotatedAngleFromPos(const QPointF& currentPoint, const QPointF& anchorPoint, const qreal& currentRotatedOffset) const
 {
     qreal deltaPoint = atan2( currentPoint.y() - anchorPoint.y(), currentPoint.x() - anchorPoint.x());
-    return radToDeg(deltaPoint) - currentRotatedOffset;
-}
-
-qreal SelectionManager::radToDeg(const qreal& radians) const
-{
-    return radians * 180.0 / M_PI;
+    return MathUtils::radToDeg(deltaPoint) - currentRotatedOffset;
 }
 
 void SelectionManager::setSelection(QRectF rect)

--- a/core_lib/src/managers/selectionmanager.cpp
+++ b/core_lib/src/managers/selectionmanager.cpp
@@ -207,7 +207,7 @@ QPointF SelectionManager::whichAnchorPoint(QPointF currentPoint)
     return anchorPoint;
 }
 
-void SelectionManager::adjustSelection(const QPointF& currentPoint, qreal offsetX, qreal offsetY, qreal rotationOffset, int incrementAmount)
+void SelectionManager::adjustSelection(const QPointF& currentPoint, qreal offsetX, qreal offsetY, qreal rotationOffset, int rotationIncrement)
 {
     QRectF& transformedSelection = mTransformedSelection;
 
@@ -243,10 +243,11 @@ void SelectionManager::adjustSelection(const QPointF& currentPoint, qreal offset
     {
         mTempTransformedSelection = transformedSelection;
         QPointF anchorPoint = transformedSelection.center();
-        mRotatedAngle = ( atan2( currentPoint.y() - anchorPoint.y(), currentPoint.x() - anchorPoint.x() ) ) * 180.0 / M_PI - rotationOffset;
-        if (incrementAmount > 0)
-        {
-            mRotatedAngle = qRound(mRotatedAngle / incrementAmount) * incrementAmount;
+        qreal rotatedAngle = rotatedAngleFromPos(currentPoint, anchorPoint, rotationOffset);
+        if (rotationIncrement > 0) {
+            mRotatedAngle = constrainRotationToAngle(rotatedAngle, rotationIncrement);
+        } else {
+            mRotatedAngle = rotatedAngle;
         }
         break;
     }
@@ -255,6 +256,21 @@ void SelectionManager::adjustSelection(const QPointF& currentPoint, qreal offset
     }
 }
 
+int SelectionManager::constrainRotationToAngle(const qreal& rotatedAngle, const int& rotationIncrement) const
+{
+    return qRound(rotatedAngle / rotationIncrement) * rotationIncrement;
+}
+
+qreal SelectionManager::rotatedAngleFromPos(const QPointF& currentPoint, const QPointF& anchorPoint, const qreal& currentRotatedOffset) const
+{
+    qreal deltaPoint = atan2( currentPoint.y() - anchorPoint.y(), currentPoint.x() - anchorPoint.x());
+    return radToDeg(deltaPoint) - currentRotatedOffset;
+}
+
+qreal SelectionManager::radToDeg(const qreal& radians) const
+{
+    return radians * 180.0 / M_PI;
+}
 
 void SelectionManager::setSelection(QRectF rect)
 {

--- a/core_lib/src/managers/selectionmanager.h
+++ b/core_lib/src/managers/selectionmanager.h
@@ -110,7 +110,6 @@ private:
 
     int constrainRotationToAngle(const qreal& rotatedAngle, const int& rotationIncrement) const;
     qreal rotatedAngleFromPos(const QPointF& currentPoint, const QPointF& anchorPoint, const qreal& currentRotatedOffset) const;
-    qreal radToDeg(const qreal& radians) const;
 
     QRectF mSelection;
     QRectF mTempTransformedSelection;

--- a/core_lib/src/managers/selectionmanager.h
+++ b/core_lib/src/managers/selectionmanager.h
@@ -51,7 +51,7 @@ public:
     bool somethingSelected() const { return mSomethingSelected; }
 
     void calculateSelectionTransformation();
-    void adjustSelection(const QPointF& currentPoint, qreal offsetX, qreal offsetY, qreal rotationOffset, int incrementAmount=0);
+    void adjustSelection(const QPointF& currentPoint, qreal offsetX, qreal offsetY, qreal rotationOffset, int rotationIncrement=0);
     MoveMode moveModeForAnchorInRange(QPointF lastPos);
     void setCurves(QList<int> curves) { mClosestCurves = curves; }
     void setVertices(QList<VertexRef> vertices) { mClosestVertices = vertices; }
@@ -107,6 +107,10 @@ signals:
     void needDeleteSelection();
 
 private:
+
+    int constrainRotationToAngle(const qreal& rotatedAngle, const int& rotationIncrement) const;
+    qreal rotatedAngleFromPos(const QPointF& currentPoint, const QPointF& anchorPoint, const qreal& currentRotatedOffset) const;
+    qreal radToDeg(const qreal& radians) const;
 
     QRectF mSelection;
     QRectF mTempTransformedSelection;

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -108,8 +108,8 @@ void HandTool::transformView(Qt::KeyboardModifiers keyMod, Qt::MouseButtons butt
         QVector2D startV(getLastPixel() - centralPixel);
         QVector2D curV(getCurrentPixel() - centralPixel);
 
-        qreal deltaPoint = static_cast<qreal>(atan2(curV.y(), curV.x()) - atan2(startV.y(), startV.x()));
-        qreal angleOffset = MathUtils::radToDeg(deltaPoint);
+        qreal angleOffset = static_cast<qreal>(atan2(curV.y(), curV.x()) - atan2(startV.y(), startV.x()));
+        angleOffset = MathUtils::radToDeg(angleOffset);
         if (keyMod & Qt::ShiftModifier)
         {
             angleOffset = qRound(angleOffset / 15) * 15;

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -17,7 +17,6 @@ GNU General Public License for more details.
 
 #include "handtool.h"
 
-#include <cmath>
 #include <QtMath>
 #include <QPixmap>
 #include <QVector2D>
@@ -29,6 +28,7 @@ GNU General Public License for more details.
 #include "strokemanager.h"
 #include "viewmanager.h"
 #include "scribblearea.h"
+#include "mathutils.h"
 
 
 HandTool::HandTool(QObject* parent) : BaseTool(parent)
@@ -108,17 +108,18 @@ void HandTool::transformView(Qt::KeyboardModifiers keyMod, Qt::MouseButtons butt
         QVector2D startV(getLastPixel() - centralPixel);
         QVector2D curV(getCurrentPixel() - centralPixel);
 
-        float angleOffset = (atan2(curV.y(), curV.x()) - atan2(startV.y(), startV.x())) * 180.0 / M_PI;
+        qreal deltaPoint = static_cast<qreal>(atan2(curV.y(), curV.x()) - atan2(startV.y(), startV.x()));
+        qreal angleOffset = MathUtils::radToDeg(deltaPoint);
         if (keyMod & Qt::ShiftModifier)
         {
             angleOffset = qRound(angleOffset / 15) * 15;
         }
-        float newAngle = viewMgr->rotation() + angleOffset;
+        float newAngle = viewMgr->rotation() + static_cast<float>(angleOffset);
         viewMgr->rotate(newAngle);
     }
     else if (isScale)
     {
-        float delta = (getCurrentPixel().y() - mLastPixel.y()) / 100.f;
+        float delta = (static_cast<float>(getCurrentPixel().y() - mLastPixel.y())) / 100.f;
         float scaleValue = viewMgr->scaling() * (1.f + delta);
         viewMgr->scale(scaleValue);
     }

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -48,6 +48,7 @@ void MoveTool::loadSettings()
     properties.useFeather = false;
     properties.stabilizerLevel = -1;
     properties.useAA = -1;
+    mRotationIncrement = mEditor->preference()->getInt(SETTING::ROTATION_INCREMENT);
 
     connect(mEditor->preference(), &PreferenceManager::optionChanged, this, &MoveTool::updateSettings);
 }
@@ -71,16 +72,6 @@ void MoveTool::updateSettings(const SETTING setting)
         break;
 
     }
-}
-
-int MoveTool::rotationAngleIncrement()
-{
-    if (mCachedRotIncrement != mRotationIncrement)
-    {
-        mRotationIncrement = mEditor->preference()->getInt(SETTING::ROTATION_INCREMENT);
-        mCachedRotIncrement = mRotationIncrement;
-    }
-    return mCachedRotIncrement;
 }
 
 void MoveTool::pointerPressEvent(PointerEvent* event)
@@ -168,7 +159,7 @@ void MoveTool::transformSelection(Qt::KeyboardModifiers keyMod, Layer* layer)
         int rotationIncrement = 0;
         if (selectMan->getMoveMode() == MoveMode::ROTATION && keyMod & Qt::ShiftModifier)
         {
-            rotationIncrement = rotationAngleIncrement();
+            rotationIncrement = mRotationIncrement;
         }
 
         if(layer->type() == Layer::BITMAP)

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 
 #include "basetool.h"
 #include "movemode.h"
+#include "preferencemanager.h"
 
 class Layer;
 class VectorImage;
@@ -48,6 +49,9 @@ private:
     void paintTransformedSelection();
     void setAnchorToLastPoint();
     void updateTransformation();
+    void updateSettings(const SETTING setting);
+
+    int rotationAngleIncrement();
 
     int showTransformWarning();
 
@@ -66,6 +70,8 @@ private:
     QPointF anchorOriginPoint;
     Layer* mCurrentLayer = nullptr;
     qreal mRotatedAngle = 0.0;
+    int mRotationIncrement = 0;
+    int mCachedRotIncrement = -1;
 };
 
 #endif

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -51,8 +51,6 @@ private:
     void updateTransformation();
     void updateSettings(const SETTING setting);
 
-    int rotationAngleIncrement();
-
     int showTransformWarning();
 
     void beginInteraction(Qt::KeyboardModifiers keyMod, Layer* layer);
@@ -71,7 +69,6 @@ private:
     Layer* mCurrentLayer = nullptr;
     qreal mRotatedAngle = 0.0;
     int mRotationIncrement = 0;
-    int mCachedRotIncrement = -1;
 };
 
 #endif

--- a/core_lib/src/util/mathutils.h
+++ b/core_lib/src/util/mathutils.h
@@ -1,0 +1,14 @@
+#ifndef MATHUTILS_H
+#define MATHUTILS_H
+
+#define M_PI 3.14159265358979323846264338327950288
+
+struct MathUtils
+{
+    inline static double radToDeg(const double& radians)
+    {
+        return radians * 180.0 / M_PI;
+    }
+};
+
+#endif // MATHUTILS_H

--- a/core_lib/src/util/mathutils.h
+++ b/core_lib/src/util/mathutils.h
@@ -3,12 +3,12 @@
 
 #define M_PI 3.14159265358979323846264338327950288
 
-struct MathUtils
+namespace MathUtils
 {
-    inline static double radToDeg(const double& radians)
+    inline double radToDeg(const double& radians)
     {
         return radians * 180.0 / M_PI;
     }
-};
+}
 
 #endif // MATHUTILS_H


### PR DESCRIPTION
Hey

I thought about writing comments but decided to refactor it myself. The implementation looks good (and you fixed the rotation not resetting woo \o/ )

Although it's probably not needed, I didn't see a reason why we should call preference manager every time we rotate the selection, so I made a method to cache the value and only update it when needed.