### PR TITLE
Refactor painter changes

### DIFF
--- a/core_lib/src/canvaspainter.h
+++ b/core_lib/src/canvaspainter.h
@@ -70,21 +70,32 @@ public:
     void ignoreTransformedSelection();
     QRect getCameraRect();
 
-    QPainter *initializePainter(QPixmap *pixmap);
-
-    void renderPreLayers(QPixmap *pixmap);
-    void renderPreLayers(QPainter *painter);
-    void renderCurLayer(QPixmap *pixmap);
-    void renderCurLayer(QPainter *painter);
-    void renderPostLayers(QPixmap *pixmap);
-    void renderPostLayers(QPainter *pixmap);
-
     void setPaintSettings(const Object* object, int currentLayer, int frame, QRect rect, BitmapImage* buffer);
     void paint();
+    void paintCached();
     void renderGrid(QPainter& painter);
+    void resetLayerCache();
+
 private:
+
+    /**
+     * @brief CanvasPainter::initializePainter
+     * Enriches the painter with a context and sets it's initial matrix.
+     * @param The in/out painter
+     * @param The paint device ie. a pixmap
+     */
+    void initializePainter(QPainter& painter, QPixmap& pixmap);
+
+    void renderPreLayers(QPainter& painter);
+    void renderCurLayer(QPainter& painter);
+    void renderPostLayers(QPainter& painter);
+
     void paintBackground();
     void paintOnionSkin(QPainter& painter);
+
+    void renderPostLayers(QPixmap *pixmap);
+    void renderCurLayer(QPixmap *pixmap);
+    void renderPreLayers(QPixmap *pixmap);
 
     void paintCurrentFrame(QPainter& painter, int startLayer, int endLayer);
 
@@ -92,7 +103,6 @@ private:
     void paintVectorFrame(QPainter&, Layer* layer, int nFrame, bool colorize, bool useLastKeyFrame, bool isCurrentFrame);
 
     void paintTransformedSelection(QPainter& painter);
-    void paintBuffer(BitmapImage *targetImage, BitmapImage *buffer, Layer::LAYER_TYPE layerType);
     void paintGrid(QPainter& painter);
     void paintCameraBorder(QPainter& painter);
     void paintAxis(QPainter& painter);
@@ -122,6 +132,9 @@ private:
     QTransform mSelectionTransform;
 
     QLoggingCategory mLog;
+
+    // Caches specificially for when drawing on the canvas
+    std::unique_ptr<QPixmap> mPreLayersCache, mPostLayersCache;
 };
 
 #endif // CANVASRENDERER_H

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -242,8 +242,6 @@ private:
 
     // Pixmap Cache keys
     std::vector<QPixmapCache::Key> mPixmapCacheKeys;
-    // Caches specificially for when drawing on the canvas
-    std::unique_ptr<QPixmap> mPreLayersCache, mPostLayersCache;
 
     // debug
     QRectF mDebugRect;


### PR DESCRIPTION
Hi

I've restructured the code so that ScribbleArea knows as little as possible, which should hopefully make it easier to understand the point of entry for CanvasPainter. Imo. anything related to painting should be happening in the painter class and not ScribbleArea. 

My hope is that we can make the painter classes very restricted and only have very few points of entry. The outside should only ever need to call paint() or paintCache() or one of the required preparation methods, the rest should be enclosed to CanvasPainter itself.

I've removed the use of QScopedPointer and instead rely on normal object initialisation and reference qpainter as a parameter. 
I read somewhere that there might be side-effects when initialising qpainter as a pointer and passing it around as such, instead a reference should be used, though I can't find the source and it's been some time since I read that post on the qt forum, so it might have changed. 

I fail to see why you want to make it a smart pointer though and not just a normal object and pass by reference but maybe I've missed something?