### PR TITLE
Fix crash because of iterator

### DIFF
--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -181,11 +181,11 @@ void Editor::retime(int newFps, qreal speed)
         }
         else
         {
-            for (auto iter = frameRemap.keys().crbegin(); iter != frameRemap.keys().crend(); iter++)
+            for (auto iter = frameRemap.constEnd(); iter != frameRemap.constBegin(); --iter)
             {
-                if (frameRemap.value(*iter) != *iter)
+                if (iter.value() != iter.key())
                 {
-                    layer->swapKeyFrames(frameRemap.value(*iter), *iter);
+                    layer->swapKeyFrames(iter.value(), iter.key());
                 }
             }
         }


### PR DESCRIPTION
Here's a small bugfix for the crash I was experiencing when retiming with a positive multiplier.
I believe the problem here was that you try to get the value of an index which is out of bound, and then it crashes.